### PR TITLE
Added Belgium Tf 0% Ot27 Eur (`BE0000351602.MOT`)

### DIFF
--- a/securities.csv
+++ b/securities.csv
@@ -31,6 +31,7 @@
 # Bond
 
 "AT0000A324S8.MOT","Austria Tf 2,9% Fb33 Eur","borsaitaliana"
+"BE0000351602.MOT","Belgium Tf 0% Ot27 Eur","borsaitaliana"
 "DE0001102358.MOT","Bund Tf 1.5% Mg24 Eur","borsaitaliana"
 "DE0001102366.MOT","Bund Tf 1% Ag24 Eur","borsaitaliana"
 "DE000BU22007.MOT","Schatz Tf 2,5% Mz25 Eur","borsaitaliana"


### PR DESCRIPTION
Fix #12 

https://www.borsaitaliana.it/borsa/obbligazioni/mot/euro-obbligazioni/scheda/BE0000351602.html?lang=it