### PR TITLE
Implement Raiffeisen.ch loader

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/enrichman/portfolio-perfomance/pkg/security/loaders/borsaitaliana"
 	"github.com/enrichman/portfolio-perfomance/pkg/security/loaders/fondidoc"
 	"github.com/enrichman/portfolio-perfomance/pkg/security/loaders/fonte"
+	"github.com/enrichman/portfolio-perfomance/pkg/security/loaders/raiffeisench"
 	"github.com/enrichman/portfolio-perfomance/pkg/security/loaders/secondapensione"
 )
 
@@ -159,6 +160,8 @@ func loadSecuritiesFromCSV(path string) error {
 		switch loader {
 		case "borsaitaliana":
 			quoteLoader = borsaitaliana.New(name, isin)
+		case "raiffeisench":
+			quoteLoader = raiffeisench.New(name, isin)
 		case "fonte":
 			quoteLoader = fonte.New(name, isin)
 		case "secondapensione":

--- a/pkg/security/loaders/raiffeisench/raiffeisench.go
+++ b/pkg/security/loaders/raiffeisench/raiffeisench.go
@@ -1,0 +1,156 @@
+package raiffeisench
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/enrichman/portfolio-perfomance/pkg/security"
+)
+
+type RaiffeisenchQuoteLoader struct {
+	name  string
+	isin  string
+	valor int
+}
+
+func New(name, isin string) *RaiffeisenchQuoteLoader {
+	valor, err := getValorFromISIN(isin)
+	if err != nil {
+		panic(err)
+	}
+
+	return &RaiffeisenchQuoteLoader{
+		name:  name,
+		isin:  isin,
+		valor: valor,
+	}
+}
+
+func getValorFromISIN(isin string) (int, error) {
+	// https://en.wikipedia.org/wiki/Valoren_number
+	// https://www.isin.org/isin-format/
+
+	if !strings.HasPrefix(isin, "CH") {
+		return 0, fmt.Errorf("valor number can only be extracted for Swiss financial instruments")
+	}
+
+	// strip CH
+	val := strings.TrimPrefix(isin, "CH")
+
+	// strip all leading zeros
+	val = strings.TrimLeft(val, "0")
+
+	// drop last digit (ISIN checksum)
+	val = val[0 : len(val)-1]
+
+	valor, err := strconv.Atoi(val)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read valor number from ISIN: %w", err)
+	}
+	return valor, nil
+}
+
+func (r *RaiffeisenchQuoteLoader) Name() string {
+	return r.name
+}
+
+func (r *RaiffeisenchQuoteLoader) ISIN() string {
+	return r.isin
+}
+
+func (r *RaiffeisenchQuoteLoader) Valor() int {
+	return r.valor
+}
+
+type HistoryQuotesRequest struct {
+	Valor      int       `json:"valor"`
+	ExchangeId int       `json:"exchangeId"`
+	CurrencyId int       `json:"currencyId"`
+	From       time.Time `json:"from"`
+	To         time.Time `json:"to"`
+}
+
+type HistoryQuotesResponse struct {
+	HistoryQuotes []struct {
+		Date  string      `json:"date"`
+		Close float64     `json:"close"`
+		Open  interface{} `json:"open"`
+		High  interface{} `json:"high"`
+		Low   interface{} `json:"low"`
+	} `json:"historyQuotes"`
+}
+
+func (r *RaiffeisenchQuoteLoader) LoadQuotes() ([]security.Quote, error) {
+	// Build request payload
+	endDate := time.Now()
+	startDate := time.Now().Add(-1 * time.Hour * 24 * 365) // one year ago
+	payload := HistoryQuotesRequest{
+		Valor:      r.valor,
+		ExchangeId: 3233,
+		CurrencyId: 1, // CHF
+		From:       startDate.UTC(),
+		To:         endDate.UTC(),
+	}
+
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling request body: %w", err)
+	}
+
+	// Build request
+	req, _ := http.NewRequest(
+		"POST",
+		"https://boerse.raiffeisen.ch/api/HistoryQuotes",
+		bytes.NewBuffer(payloadBytes),
+	)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-type", "application/json")
+	// We need to directly set the key in the header map,
+	// because Go's stdlib canonicalizes all HTTP headers,
+	// but the remote API requires this header to be lowercase.
+	req.Header["customer"] = []string{"raiffeisen-prod"}
+
+	// fmt.Println(req)
+
+	// Create an HTTP client and send the request
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error during get request: %w", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server replied with unexpected status code '%s'", res.Status)
+	}
+	// fmt.Println(res.StatusCode)
+	// fmt.Println(res.Header)
+
+	// Read and parse response body
+	var result HistoryQuotesResponse
+	reader := res.Body
+	// reader = io.TeeReader(res.Body, os.Stdout)
+	err = json.NewDecoder(reader).Decode(&result)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshaling body: %w", err)
+	}
+
+	// Convert into the desired return format
+	quotes := make([]security.Quote, 0, len(result.HistoryQuotes))
+	for _, quote := range result.HistoryQuotes {
+		date, err := time.Parse(time.RFC3339, quote.Date+"Z")
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse date '%s' of quote: %w", quote.Date, err)
+		}
+		quotes = append(quotes, security.Quote{
+			Date:  date,
+			Close: float32(quote.Close),
+		})
+	}
+
+	return quotes, nil
+}


### PR DESCRIPTION
Hello,

first of all: thank you for starting this awesome project!

I've started to use Portfolio-Performance but was still lacking a data source for my Swiss securities.
It's a bit that Portfolio-Performance does not have a plugin system and I wanted to avoid manually importing the data (after all, what am I using a computer for?).
I think your solution of having a nightly cronjob and publishing the JSON data with Github Pages is really elegant!

I implemented an additional loader based on the Raiffeisen.ch portal [1] that allows tracking securities traded on the Swiss stock exchange (SIX) [2]. I also added several Swisscanto ETFs [3] and downloaded up to 10 years worth of historical data for them.

Cheers!

* [1] https://boerse.raiffeisen.ch/
* [2] https://www.six-group.com/en/market-data.html
* [3] https://products.swisscanto.com/products/product?lang=en