### PR TITLE
Add BTP Futura Nv33 Eur (IT0005466351)

### DIFF
--- a/securities.csv
+++ b/securities.csv
@@ -39,6 +39,7 @@
 
 "IT0003934657.MOT","Btp-1fb37 4% Eur","borsaitaliana"
 "IT0005425761.MOT","Btp Futura Nv28 Eur","borsaitaliana"
+"IT0005466351.MOT","Btp Futura Nv33 Eur","borsaitaliana"
 "IT0005559817.MOT","Bot Zc Ag24 A Eur","borsaitaliana"
 "IT0005631608.MOT","Btp Green Fx 4.1% Apr46 Eur","borsaitaliana"
 "IT0005634800.MOT","Btp Piu' Sc Fb33 Eur","borsaitaliana"


### PR DESCRIPTION
## Add BTP Futura Nov 2033 (IT0005466351)

This PR adds **BTP Futura Nv33** to `securities.csv`:

```csv
"IT0005466351.MOT","Btp Futura Nv33 Eur","borsaitaliana"
```

**Details**
- ISIN: `IT0005466351`
- Instrument: BTP Futura — 4th issue (Nov 2021), step-up coupons, maturity **2033-11-16**
- Listed on Borsa Italiana **MOT**
- Naming follows the existing convention (see `"IT0005425761.MOT","Btp Futura Nv28 Eur","borsaitaliana"`)

Thanks for maintaining this dataset!

🤖 Generated with [Claude Code](https://claude.com/claude-code)
